### PR TITLE
Remove binary template images and add placeholder README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+DB_HOST=localhost
+DB_NAME=paystub
+DB_USER=root
+DB_PASS=secret
+STRIPE_PK=pk_test_xxx
+STRIPE_SK=sk_test_xxx
+MP_ACCESS_TOKEN=mp_test_xxx
+SMTP_HOST=smtp.example.com
+SMTP_USER=user@example.com
+SMTP_PASS=secret

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/vendor/
+.env
+/storage/paystubs/*
+!/storage/paystubs/.gitkeep
+!/storage/paystubs/.htaccess
+/storage/tmp/*
+!/storage/tmp/.gitkeep

--- a/app/Config/app.php
+++ b/app/Config/app.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'multi_tenant' => true,
+];

--- a/app/Config/payments.php
+++ b/app/Config/payments.php
@@ -1,0 +1,10 @@
+<?php
+return [
+    'stripe' => [
+        'public_key' => getenv('STRIPE_PK'),
+        'secret_key' => getenv('STRIPE_SK'),
+    ],
+    'mercadopago' => [
+        'access_token' => getenv('MP_ACCESS_TOKEN'),
+    ],
+];

--- a/app/Config/templates.php
+++ b/app/Config/templates.php
@@ -1,0 +1,13 @@
+<?php
+return [
+    'horizontal-blue' => [
+        'name' => 'Horizontal Blue',
+        'preview' => '/assets/templates/horizontal-blue.png',
+        'file' => 'pdf-layout-horizontal-blue.php'
+    ],
+    'black' => [
+        'name' => 'Black',
+        'preview' => '/assets/templates/black.png',
+        'file' => 'pdf-layout-black.php'
+    ],
+];

--- a/app/Controllers/CheckoutController.php
+++ b/app/Controllers/CheckoutController.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Controllers;
+
+class CheckoutController
+{
+    public function createSession()
+    {
+        // TODO: integrate payment provider
+    }
+}

--- a/app/Controllers/FormController.php
+++ b/app/Controllers/FormController.php
@@ -1,0 +1,17 @@
+<?php
+namespace App\Controllers;
+
+class FormController
+{
+    public function showForm()
+    {
+        // Render the form view
+        include __DIR__ . '/../Views/form.php';
+    }
+
+    public function preview()
+    {
+        // Render the preview view
+        include __DIR__ . '/../Views/preview.php';
+    }
+}

--- a/app/Controllers/OrderController.php
+++ b/app/Controllers/OrderController.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Controllers;
+
+class OrderController
+{
+    public function create()
+    {
+        // TODO: handle order creation
+    }
+}

--- a/app/Controllers/PdfController.php
+++ b/app/Controllers/PdfController.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Controllers;
+
+class PdfController
+{
+    public function generate()
+    {
+        // TODO: generate and return PDFs
+    }
+}

--- a/app/Controllers/TemplateController.php
+++ b/app/Controllers/TemplateController.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Controllers;
+
+class TemplateController
+{
+    public function list()
+    {
+        // TODO: return available templates
+    }
+}

--- a/app/Controllers/WebhookController.php
+++ b/app/Controllers/WebhookController.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Controllers;
+
+class WebhookController
+{
+    public function handle()
+    {
+        // TODO: process payment webhooks
+    }
+}

--- a/app/Models/DeductionItem.php
+++ b/app/Models/DeductionItem.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Models;
+
+class DeductionItem
+{
+    // TODO: define properties for deduction items
+}

--- a/app/Models/EarningItem.php
+++ b/app/Models/EarningItem.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Models;
+
+class EarningItem
+{
+    // TODO: define properties for earning items
+}

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Models;
+
+class Order
+{
+    // TODO: define properties and methods for Order model
+}

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Models;
+
+class Payment
+{
+    // TODO: define properties for payments
+}

--- a/app/Models/TaxItem.php
+++ b/app/Models/TaxItem.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Models;
+
+class TaxItem
+{
+    // TODO: define properties for tax items
+}

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Models;
+
+class Tenant
+{
+    // TODO: define properties for tenants
+}

--- a/app/Services/EmailService.php
+++ b/app/Services/EmailService.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Services;
+
+class EmailService
+{
+    public function send(string $to, string $subject, string $body, array $attachments = []): void
+    {
+        // TODO: send email via SMTP
+    }
+}

--- a/app/Services/OrdersService.php
+++ b/app/Services/OrdersService.php
@@ -1,0 +1,11 @@
+<?php
+namespace App\Services;
+
+class OrdersService
+{
+    public function save(array $data): string
+    {
+        // TODO: persist order and return ID
+        return '';
+    }
+}

--- a/app/Services/PaymentsService.php
+++ b/app/Services/PaymentsService.php
@@ -1,0 +1,11 @@
+<?php
+namespace App\Services;
+
+class PaymentsService
+{
+    public function createSession(string $provider, array $data): array
+    {
+        // TODO: create payment session
+        return [];
+    }
+}

--- a/app/Services/PdfService.php
+++ b/app/Services/PdfService.php
@@ -1,0 +1,11 @@
+<?php
+namespace App\Services;
+
+class PdfService
+{
+    public function render(string $template, array $data, bool $watermark = false): string
+    {
+        // TODO: convert HTML to PDF
+        return '';
+    }
+}

--- a/app/Services/PeriodsService.php
+++ b/app/Services/PeriodsService.php
@@ -1,0 +1,11 @@
+<?php
+namespace App\Services;
+
+class PeriodsService
+{
+    public function generate(string $schedule, int $count): array
+    {
+        // TODO: generate pay periods
+        return [];
+    }
+}

--- a/app/Services/PricingService.php
+++ b/app/Services/PricingService.php
@@ -1,0 +1,11 @@
+<?php
+namespace App\Services;
+
+class PricingService
+{
+    public function calculate(int $count, string $templateKey): float
+    {
+        // TODO: implement pricing rules
+        return 0.0;
+    }
+}

--- a/app/Services/TenantsService.php
+++ b/app/Services/TenantsService.php
@@ -1,0 +1,11 @@
+<?php
+namespace App\Services;
+
+class TenantsService
+{
+    public function current(): array
+    {
+        // TODO: detect tenant based on host
+        return [];
+    }
+}

--- a/app/Services/TokenService.php
+++ b/app/Services/TokenService.php
@@ -1,0 +1,11 @@
+<?php
+namespace App\Services;
+
+class TokenService
+{
+    public function generate(string $id): string
+    {
+        // TODO: generate temporary download token
+        return '';
+    }
+}

--- a/app/Views/email-receipt.php
+++ b/app/Views/email-receipt.php
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Your Paystubs</title>
+</head>
+<body>
+    <p>Thank you for your purchase. Your paystubs are attached.</p>
+</body>
+</html>

--- a/app/Views/form.php
+++ b/app/Views/form.php
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Paystub Form</title>
+</head>
+<body>
+    <h1>Paystub Form</h1>
+    <form method="POST" action="/preview">
+        <!-- TODO: form fields -->
+        <button type="submit">Preview</button>
+    </form>
+</body>
+</html>

--- a/app/Views/pdf-layout-black.php
+++ b/app/Views/pdf-layout-black.php
@@ -1,0 +1,3 @@
+<div style="width:100%;height:100%;background:#000;color:#fff;">
+    <!-- TODO: Black template -->
+</div>

--- a/app/Views/pdf-layout-horizontal-blue.php
+++ b/app/Views/pdf-layout-horizontal-blue.php
@@ -1,0 +1,3 @@
+<div style="width:100%;height:100%;background:#eef;">
+    <!-- TODO: Horizontal Blue template -->
+</div>

--- a/app/Views/preview.php
+++ b/app/Views/preview.php
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Paystub Preview</title>
+</head>
+<body>
+    <h1>Preview</h1>
+    <!-- TODO: show preview with watermark -->
+</body>
+</html>

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "paystub/paystub",
+    "description": "Pay stub generator without framework.",
+    "type": "project",
+    "require": {
+        "dompdf/dompdf": "^2.0",
+        "guzzlehttp/guzzle": "^7.0",
+        "stripe/stripe-php": "^10.0",
+        "mercadopago/dx-php": "^2.5",
+        "phpmailer/phpmailer": "^6.0",
+        "vlucas/phpdotenv": "^5.5",
+        "altorouter/altorouter": "^2.0",
+        "ramsey/uuid": "^4.0",
+        "monolog/monolog": "^3.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    }
+}

--- a/database.sql
+++ b/database.sql
@@ -1,0 +1,99 @@
+-- Initial database schema
+
+CREATE TABLE tenants (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    domain VARCHAR(255) NOT NULL,
+    brand_name VARCHAR(255) NOT NULL,
+    logo_url VARCHAR(255),
+    currency VARCHAR(10) NOT NULL,
+    watermark_text VARCHAR(255),
+    price_per_stub DECIMAL(10,2),
+    stripe_pk VARCHAR(255),
+    stripe_sk VARCHAR(255),
+    mp_keys VARCHAR(255),
+    email_from VARCHAR(255)
+);
+
+CREATE TABLE orders (
+    id CHAR(36) PRIMARY KEY,
+    tenant_id INT,
+    email VARCHAR(255) NOT NULL,
+    status ENUM('draft','pending','paid') NOT NULL DEFAULT 'draft',
+    template_key VARCHAR(100) NOT NULL,
+    pay_schedule ENUM('weekly','biweekly','semi-monthly','monthly') NOT NULL,
+    count_stubs INT NOT NULL,
+    bundle_mode ENUM('combined','separate') NOT NULL DEFAULT 'separate',
+    period_start DATE,
+    period_end DATE,
+    pay_date DATE,
+    gross DECIMAL(10,2),
+    net DECIMAL(10,2),
+    fit_taxable_wages DECIMAL(10,2),
+    taxes_total DECIMAL(10,2),
+    deductions_total DECIMAL(10,2),
+    employee_json JSON,
+    employer_json JSON,
+    pdf_path VARCHAR(255),
+    version_of CHAR(36),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (tenant_id) REFERENCES tenants(id)
+);
+
+CREATE TABLE earnings (
+    order_id CHAR(36) NOT NULL,
+    stub_index INT NOT NULL,
+    label VARCHAR(100) NOT NULL,
+    hours DECIMAL(10,2),
+    rate DECIMAL(10,2),
+    current_amount DECIMAL(10,2) NOT NULL,
+    ytd_amount DECIMAL(10,2) NOT NULL,
+    sort_order INT DEFAULT 0,
+    PRIMARY KEY (order_id, stub_index, label),
+    FOREIGN KEY (order_id) REFERENCES orders(id)
+);
+
+CREATE TABLE deductions (
+    order_id CHAR(36) NOT NULL,
+    stub_index INT NOT NULL,
+    label VARCHAR(100) NOT NULL,
+    pretax BOOLEAN DEFAULT 0,
+    current_amount DECIMAL(10,2) NOT NULL,
+    ytd_amount DECIMAL(10,2) NOT NULL,
+    sort_order INT DEFAULT 0,
+    PRIMARY KEY (order_id, stub_index, label),
+    FOREIGN KEY (order_id) REFERENCES orders(id)
+);
+
+CREATE TABLE taxes (
+    order_id CHAR(36) NOT NULL,
+    stub_index INT NOT NULL,
+    label VARCHAR(100) NOT NULL,
+    current_amount DECIMAL(10,2) NOT NULL,
+    ytd_amount DECIMAL(10,2) NOT NULL,
+    sort_order INT DEFAULT 0,
+    PRIMARY KEY (order_id, stub_index, label),
+    FOREIGN KEY (order_id) REFERENCES orders(id)
+);
+
+CREATE TABLE payments (
+    order_id CHAR(36) NOT NULL,
+    provider ENUM('stripe','mp') NOT NULL,
+    session_id VARCHAR(255),
+    status VARCHAR(50),
+    currency VARCHAR(10),
+    amount_total DECIMAL(10,2),
+    webhook_payload_json JSON,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (order_id, provider),
+    FOREIGN KEY (order_id) REFERENCES orders(id)
+);
+
+CREATE TABLE audit_logs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    actor ENUM('user','bot') NOT NULL,
+    action ENUM('create','regenerate','resend') NOT NULL,
+    order_id CHAR(36),
+    meta_json JSON,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (order_id) REFERENCES orders(id)
+);

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,4 @@
+RewriteEngine On
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^ index.php [QSA,L]

--- a/public/assets/templates/README.md
+++ b/public/assets/templates/README.md
@@ -1,0 +1,3 @@
+# Template Images
+
+Template PNG files should be placed here. They are omitted from the repository to avoid binary file issues.

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,15 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+
+$router = new AltoRouter();
+
+$router->map('GET', '/', function () {
+    echo 'Paystub app';
+});
+
+$match = $router->match();
+if ($match && is_callable($match['target'])) {
+    call_user_func_array($match['target'], $match['params']);
+} else {
+    header($_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found');
+}

--- a/storage/paystubs/.gitkeep
+++ b/storage/paystubs/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure directory exists for generated paystub PDFs

--- a/storage/paystubs/.htaccess
+++ b/storage/paystubs/.htaccess
@@ -1,0 +1,1 @@
+Deny from all

--- a/storage/tmp/.gitkeep
+++ b/storage/tmp/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure directory exists for temporary files


### PR DESCRIPTION
## Summary
- remove committed template PNG assets to satisfy text-only restrictions
- add README placeholder in `public/assets/templates` instructing where to place images

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n 1 php -l`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68b093af0e708332a69a3de22e0ad9f7